### PR TITLE
[Feature] Generate App

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// appCmd represents the app command
+var appCmd = &cobra.Command{
+	Use:   "app",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("app called")
+	},
+}
+
+func init() {
+	generateCmd.AddCommand(appCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// appCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// appCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1,32 +1,64 @@
 /*
 Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-
 */
 package cmd
 
 import (
+	"be-cli/util"
+	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 )
 
 // appCmd represents the app command
 var appCmd = &cobra.Command{
-	Use:   "app",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
+	Use:          "app [<name>]",
+	Short:        "Generate app [<name>] components",
+	Long:         ``,
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("app called")
+	RunE: func(cmd *cobra.Command, args []string) error {
+		appName := args[0]
+
+		if err := os.Chdir("app"); err != nil {
+			return errors.New("unable to locate app folder in the current working directory")
+		}
+
+		// Create and write all the required folders and .go files for the app
+		dirNames := [3]string{"handler", "repository", "usecase"}
+
+		for _, dirName := range dirNames {
+			dirNamePath := filepath.Join(appName, dirName, fmt.Sprintf("%s_%s.go", appName, dirName))
+			if err := createAndWriteFile(dirNamePath, dirName); err != nil {
+				return err
+			}
+
+			dirNamePath = filepath.Join(appName, dirName, fmt.Sprintf("%s_%s_test.go", appName, dirName))
+			if err := createAndWriteFile(dirNamePath, dirName); err != nil {
+				return err
+			}
+		}
+
+		for _, dirName := range dirNames[1:] {
+			dirNamePath := filepath.Join(appName, dirName, fmt.Sprintf("%s_%s_mock.go", appName, dirName))
+			if err := createAndWriteFile(dirNamePath, dirName); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	},
 }
 
 func init() {
-	generateCmd.AddCommand(appCmd)
+	// appCmd.Flags().StringVarP(&name, "name", "n", "", "sets the app's generated name")
+	// if err := appCmd.MarkFlagRequired("name"); err != nil {
+	// 	fmt.Println(err.Error())
+	// }
 
 	// Here you will define your flags and configuration settings.
 
@@ -37,4 +69,19 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// appCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	generateCmd.AddCommand(appCmd)
+}
+
+func createAndWriteFile(filePath, packageName string) error {
+	fi, err := util.CreateFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	_, err = fi.Write([]byte("package " + packageName))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -78,24 +78,10 @@ var appCmd = &cobra.Command{
 }
 
 func init() {
-	// appCmd.Flags().StringVarP(&name, "name", "n", "", "sets the app's generated name")
-	// if err := appCmd.MarkFlagRequired("name"); err != nil {
-	// 	fmt.Println(err.Error())
-	// }
-
 	appCmd.Flags().BoolVar(&appOpts.handler, "handler", false, "Generate handler component")
 	appCmd.Flags().BoolVar(&appOpts.repository, "repository", false, "Generate repository component")
 	appCmd.Flags().BoolVar(&appOpts.usecase, "usecase", false, "Generate usecase component")
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// appCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// appCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 	generateCmd.AddCommand(appCmd)
 }
 

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -58,18 +58,17 @@ var appCmd = &cobra.Command{
 		}
 
 		// Generate component based on specified flag
-		switch {
-		case appOpts.handler:
+		if appOpts.handler {
 			if err := generateComponent(appName, "handler"); err != nil {
 				return err
 			}
-
-		case appOpts.repository:
+		}
+		if appOpts.repository {
 			if err := generateComponentWithMock(appName, "repository"); err != nil {
 				return err
 			}
-
-		case appOpts.usecase:
+		}
+		if appOpts.usecase {
 			if err := generateComponentWithMock(appName, "usecase"); err != nil {
 				return err
 			}

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/gobeam/stringy"
 	"github.com/spf13/cobra"
 )
 
@@ -31,7 +32,7 @@ var appCmd = &cobra.Command{
 
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Create and Change current working directory to the new app
-		appName := args[0]
+		appName := stringy.New(args[0]).SnakeCase().ToLower()
 		if err := os.MkdirAll("app/"+appName, os.ModePerm); err != nil {
 			return err
 		}
@@ -88,12 +89,12 @@ func init() {
 // Generate a Component along with its folder. This also include file and test file
 func generateComponent(appName string, componentName string) error {
 	pathStr := path.Join(componentName, fmt.Sprintf("%s_%s.go", appName, componentName))
-	if err := createAndWriteFile(pathStr); err != nil {
+	if err := createAndWriteFile(pathStr, componentName); err != nil {
 		return err
 	}
 
 	pathStr = pathStr[:strings.Index(pathStr, ".go")] + "_test.go"
-	if err := createAndWriteFile(pathStr); err != nil {
+	if err := createAndWriteFile(pathStr, componentName); err != nil {
 		return err
 	}
 
@@ -107,7 +108,7 @@ func generateComponentWithMock(appName string, componentName string) error {
 	}
 
 	pathStr := path.Join(componentName, fmt.Sprintf("%s_%s_mock.go", appName, componentName))
-	if err := createAndWriteFile(pathStr); err != nil {
+	if err := createAndWriteFile(pathStr, componentName); err != nil {
 		return err
 	}
 
@@ -115,16 +116,13 @@ func generateComponentWithMock(appName string, componentName string) error {
 }
 
 // Create and Write File components that include package name inside
-func createAndWriteFile(filePath string) error {
+func createAndWriteFile(filePath string, componentName string) error {
 	fi, err := util.CreateFile(filePath)
 	if err != nil {
 		return err
 	}
 
-	// Ensure correct package name
-	pkgName := strings.Replace("package "+strings.Split(filePath, "_")[1], ".go", "", 1)
-
-	_, err = fi.Write([]byte(pkgName))
+	_, err = fi.Write([]byte("package " + componentName))
 	if err != nil {
 		return err
 	}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,0 +1,40 @@
+/*
+Copyright © 2023 NAME HERE <EMAIL ADDRESS>
+
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// generateCmd represents the generate command
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "A brief description of your command",
+	Long: `A longer description that spans multiple lines and likely contains examples
+and usage of using your command. For example:
+
+Cobra is a CLI library for Go that empowers applications.
+This application is a tool to generate the needed files
+to quickly create a Cobra application.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("generate called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(generateCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// generateCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// generateCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,28 +1,18 @@
 /*
 Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-
 */
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
 // generateCmd represents the generate command
 var generateCmd = &cobra.Command{
-	Use:   "generate",
-	Short: "A brief description of your command",
-	Long: `A longer description that spans multiple lines and likely contains examples
-and usage of using your command. For example:
-
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("generate called")
-	},
+	Use:   "generate <command>",
+	Short: "Generate architecture component",
+	Long:  ``,
+	// Run: func(cmd *cobra.Command, args []string) {},
 }
 
 func init() {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,6 +1,5 @@
 /*
 Copyright © 2023 NAME HERE <EMAIL ADDRESS>
-
 */
 package cmd
 
@@ -65,7 +64,7 @@ var initCmd = &cobra.Command{
 			fmt.Println("successed: Make directory app")
 		}
 
-		if err := util.CreateFile("cmd/main.go"); err != nil {
+		if _, err := util.CreateFile("cmd/main.go"); err != nil {
 			fmt.Println(err)
 			return
 		} else {
@@ -100,7 +99,7 @@ var initCmd = &cobra.Command{
 			fmt.Println("successed: Make directory middleware")
 		}
 
-		if err := util.CreateFile("rest/rest.go"); err != nil {
+		if _, err := util.CreateFile("rest/rest.go"); err != nil {
 			fmt.Println(err)
 			return
 		} else {
@@ -114,35 +113,35 @@ var initCmd = &cobra.Command{
 			fmt.Println("successed: Make directory util")
 		}
 
-		if err := util.CreateFile(".env"); err != nil {
+		if _, err := util.CreateFile(".env"); err != nil {
 			fmt.Println(err)
 			return
 		} else {
 			fmt.Println("successed: Make file .env")
 		}
 
-		if err := util.CreateFile(".gitignore"); err != nil {
+		if _, err := util.CreateFile(".gitignore"); err != nil {
 			fmt.Println(err)
 			return
 		} else {
 			fmt.Println("successed: Make file .gitignore")
 		}
 
-		if err := util.CreateFile("README.md"); err != nil {
+		if _, err := util.CreateFile("README.md"); err != nil {
 			fmt.Println(err)
 			return
 		} else {
 			fmt.Println("successed: Make file README.md")
 		}
 
-		if err := util.CreateFile("Dockerfile"); err != nil {
+		if _, err := util.CreateFile("Dockerfile"); err != nil {
 			fmt.Println(err)
 			return
 		} else {
 			fmt.Println("successed: Make file Dockerfile")
 		}
 
-		if err := util.CreateFile("docker-compose.yaml"); err != nil {
+		if _, err := util.CreateFile("docker-compose.yaml"); err != nil {
 			fmt.Println(err)
 			return
 		} else {

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,11 @@ module be-cli
 go 1.18
 
 require (
-	github.com/gobeam/stringy v0.0.6 // indirect
+	github.com/gobeam/stringy v0.0.6
+	github.com/spf13/cobra v1.7.0
+)
+
+require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.7.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/util/util.go
+++ b/util/util.go
@@ -8,28 +8,26 @@ import (
 	"strings"
 )
 
-func CreateFile(name string) (file *os.File, err error) {
-	_, err = os.Stat(name)
+func CreateFile(name string) (*os.File, error) {
 
-	if os.IsNotExist(err) {
-		if strings.ContainsAny(name, "/\\") {
-			path := name[:strings.LastIndexAny(name, "/\\")]
-
-			err = os.MkdirAll(path, os.ModePerm)
-			if err != nil {
-				return nil, err
-			}
-		}
-
-		file, err = os.Create(name)
-		if err != nil {
-			return nil, err
-		}
-	} else {
+	if _, err := os.Stat(name); os.IsExist(err) {
 		return nil, errors.New("file already exist")
 	}
 
-	return file, nil
+	if strings.ContainsAny(name, "/\\") {
+		path := name[:strings.LastIndexAny(name, "/\\")]
+
+		if err := os.MkdirAll(path, os.ModePerm); err != nil {
+			return nil, err
+		}
+	}
+
+	fl, err := os.Create(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return fl, nil
 }
 
 func ExecuteCommand(command string) (string, error) {

--- a/util/util.go
+++ b/util/util.go
@@ -8,28 +8,28 @@ import (
 	"strings"
 )
 
-func CreateFile(name string) error {
-	_, err := os.Stat(name)
+func CreateFile(name string) (file *os.File, err error) {
+	_, err = os.Stat(name)
 
 	if os.IsNotExist(err) {
 		if strings.Contains(name, "/") {
 			path := name[:strings.LastIndex(name, "/")]
 
-			err := os.MkdirAll(path, os.ModePerm)
+			err = os.MkdirAll(path, os.ModePerm)
 			if err != nil {
-				return err
+				return nil, err
 			}
 		}
 
-		_, err = os.Create(name)
+		file, err = os.Create(name)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	} else {
-		return errors.New("file already exist")
+		return nil, errors.New("file already exist")
 	}
 
-	return nil
+	return file, nil
 }
 
 func ExecuteCommand(command string) (string, error) {

--- a/util/util.go
+++ b/util/util.go
@@ -1,7 +1,6 @@
 package util
 
 import (
-	"errors"
 	"os"
 	"os/exec"
 	"runtime"
@@ -9,11 +8,6 @@ import (
 )
 
 func CreateFile(name string) (*os.File, error) {
-
-	if _, err := os.Stat(name); os.IsExist(err) {
-		return nil, errors.New("file already exist")
-	}
-
 	if strings.ContainsAny(name, "/\\") {
 		path := name[:strings.LastIndexAny(name, "/\\")]
 
@@ -22,7 +16,7 @@ func CreateFile(name string) (*os.File, error) {
 		}
 	}
 
-	fl, err := os.Create(name)
+	fl, err := os.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0666)
 	if err != nil {
 		return nil, err
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -12,8 +12,8 @@ func CreateFile(name string) (file *os.File, err error) {
 	_, err = os.Stat(name)
 
 	if os.IsNotExist(err) {
-		if strings.Contains(name, "/") {
-			path := name[:strings.LastIndex(name, "/")]
+		if strings.ContainsAny(name, "/\\") {
+			path := name[:strings.LastIndexAny(name, "/\\")]
 
 			err = os.MkdirAll(path, os.ModePerm)
 			if err != nil {


### PR DESCRIPTION
Introduce the ``generate`` command as a root command. This command is not standalone; it requires a sub-command to pair with it. In this Pull Request, I have also added the ``app`` command. The purpose of the ``generate app`` command is to create a folder and a file with a name specified by the user when running the command. The app consists of three components: a handler, a repository, and a use case. Each component has its own file, test file, and some mock files. Additionally, users can specify which component to generate by providing a flag with the component name.

Example 

> generate app user
> generate app user --handler --usecase
> generate app mahasiswa --repository